### PR TITLE
:recycle: コンテキストと状態をコンポーネントから分離

### DIFF
--- a/src/components/test_use_context_2/Child.tsx
+++ b/src/components/test_use_context_2/Child.tsx
@@ -1,6 +1,6 @@
 import { FC, useContext } from 'react';
 
-import { ParentContext } from './Parent';
+import { ParentContext } from './ContextProvider';
 
 const Child: FC = () => {
   // 3. Context Valueの取得

--- a/src/components/test_use_context_2/ChildSecond.tsx
+++ b/src/components/test_use_context_2/ChildSecond.tsx
@@ -1,6 +1,6 @@
 import { FC, useContext } from 'react';
 
-import { ParentContext } from './Parent';
+import { ParentContext } from './ContextProvider';
 
 const ChildSecond: FC = () => {
   // 3. Context Valueの取得

--- a/src/components/test_use_context_2/ContextProvider.tsx
+++ b/src/components/test_use_context_2/ContextProvider.tsx
@@ -1,0 +1,25 @@
+import {
+  Dispatch,
+  FC,
+  PropsWithChildren,
+  SetStateAction,
+  createContext,
+  useState,
+} from 'react';
+
+// 1. contextの作成
+type ParentContextType = [number, Dispatch<SetStateAction<number>>];
+export const ParentContext = createContext<ParentContextType>({} as never);
+
+const ContextProvider: FC<PropsWithChildren> = ({ children }) => {
+  const [state, setState] = useState(0);
+
+  return (
+    // 2. Provider valueに、状態を更新関数を指定
+    <ParentContext.Provider value={[state, setState]}>
+      {children}
+    </ParentContext.Provider>
+  );
+};
+
+export default ContextProvider;

--- a/src/components/test_use_context_2/Parent.tsx
+++ b/src/components/test_use_context_2/Parent.tsx
@@ -1,22 +1,16 @@
-import { Dispatch, FC, SetStateAction, createContext, useState } from 'react';
+import { FC } from 'react';
 
 import Child from './Child';
 import ChildSecond from './ChildSecond';
-
-// 1. contextの作成
-type ParentContextType = [number, Dispatch<SetStateAction<number>>];
-export const ParentContext = createContext<ParentContextType>({} as never);
+import ContextProvider from './ContextProvider';
 
 const Parent: FC = () => {
-  const [state, setState] = useState(0);
-
   return (
-    // 2. Provider valueに、状態を更新関数を指定
-    <ParentContext.Provider value={[state, setState]}>
+    <ContextProvider>
       <h1>Parent</h1>
       <Child />
       <ChildSecond />
-    </ParentContext.Provider>
+    </ContextProvider>
   );
 };
 


### PR DESCRIPTION
### 概要
コンテキストと状態をコンポーネントから分離することで保守性を向上させた

- [x] [♻️ コンテキストと状態をコンポーネントから分離](https://github.com/PenPeen/react_practice/commit/9bc0d28a2a976360a4d54a179368e73797d9e24a) 