### PR TITLE
useReducer + useContext を使用したグローバルな状態管理

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import './App.css';
-import Parent from './components/test_use_context_2/Parent';
+import Parent from './components/test_use_context_3/Parent';
 import Providers from './Providers';
 
 function App() {

--- a/src/components/test_use_context_3/Child.tsx
+++ b/src/components/test_use_context_3/Child.tsx
@@ -1,0 +1,18 @@
+import { FC, useContext } from 'react';
+
+import { ParentContext } from './ContextProvider';
+
+const Child: FC = () => {
+  // 3. Context Valueの取得
+  const [state, hogeUp] = useContext(ParentContext);
+
+  return (
+    <>
+      <h2>Child</h2>
+      <button onClick={hogeUp}>hogeUp</button>
+      <p>state = {state}</p>
+    </>
+  );
+};
+
+export default Child;

--- a/src/components/test_use_context_3/ChildSecond.tsx
+++ b/src/components/test_use_context_3/ChildSecond.tsx
@@ -1,0 +1,17 @@
+import { FC, useContext } from 'react';
+
+import { ParentContext } from './ContextProvider';
+
+const ChildSecond: FC = () => {
+  // 3. Context Valueの取得
+  const [, , hogeDown] = useContext(ParentContext);
+
+  return (
+    <>
+      <h2>ChildSecond</h2>
+      <button onClick={hogeDown}>hogeDown</button>
+    </>
+  );
+};
+
+export default ChildSecond;

--- a/src/components/test_use_context_3/ContextProvider.tsx
+++ b/src/components/test_use_context_3/ContextProvider.tsx
@@ -1,0 +1,41 @@
+import { FC, PropsWithChildren, createContext, useReducer } from 'react';
+
+import { createSlice } from '@reduxjs/toolkit';
+
+// 1. contextの作成
+type ParentContextType = [string, () => void, () => void];
+export const ParentContext = createContext<ParentContextType>({} as never);
+
+type HogeState = { value: string };
+const initialState: HogeState = { value: 'hoge' };
+
+const hogeSlice = createSlice({
+  name: 'hoge',
+  initialState,
+  reducers: {
+    hogeUp(state) {
+      state.value += '↑';
+    },
+    hogeDown(state) {
+      state.value += '↓';
+    },
+  },
+});
+
+const { actions, reducer } = hogeSlice;
+const { hogeUp, hogeDown } = actions;
+
+const ContextProvider: FC<PropsWithChildren> = ({ children }) => {
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const handleHogeUp = () => dispatch(hogeUp());
+  const handleHogeDown = () => dispatch(hogeDown());
+
+  return (
+    // 2. Provider valueに、状態を更新関数を指定
+    <ParentContext.Provider value={[state.value, handleHogeUp, handleHogeDown]}>
+      {children}
+    </ParentContext.Provider>
+  );
+};
+
+export default ContextProvider;

--- a/src/components/test_use_context_3/Parent.tsx
+++ b/src/components/test_use_context_3/Parent.tsx
@@ -1,0 +1,17 @@
+import { FC } from 'react';
+
+import Child from './Child';
+import ChildSecond from './ChildSecond';
+import ContextProvider from './ContextProvider';
+
+const Parent: FC = () => {
+  return (
+    <ContextProvider>
+      <h1>Parent</h1>
+      <Child />
+      <ChildSecond />
+    </ContextProvider>
+  );
+};
+
+export default Parent;


### PR DESCRIPTION
### 概要
- [x]  [✨ useReducer + useContext](https://github.com/PenPeen/react_practice/commit/8914384896b5facc80f5c8e4d4ec923e1a3da589)
- [x] [⚡ Child, Parentの定義](https://github.com/PenPeen/react_practice/commit/bcaca42aa10b838ba2e3d0ebc6bb6a34f17d2db8)